### PR TITLE
fix(readme): change clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ cd typegraphql-prisma-crud
 npm install
 ```
 
+or 
+
+```
+cd typegraphql-prisma-crud
+yarn
+```
+
+
+and generate the schema:
+
+```
+npx prisma generate
+```
+
+or:
+
+```
+yarn prisma generate
+```
+
 
 ### 2. Start the GraphQL server
 
@@ -27,6 +47,13 @@ Launch your GraphQL server with this command:
 ```
 npm run dev
 ```
+
+or 
+
+```
+yarn run dev
+```
+
 
 Navigate to [http://localhost:4000](http://localhost:4000) in your browser to explore the CRUD API of your GraphQL server in a [GraphQL Playground](https://github.com/prisma/graphql-playground). 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This example shows how to **implement a CRUD GraphQL API with TypeScript** based
 Clone this repository:
 
 ```
-git clone git@github.com:nikolasburk/typegraphql-prisma-crud.git --depth=1
+git clone https://github.com/nikolasburk/typegraphql-prisma-crud.git --depth=1
 ```
 
 Install npm dependencies:


### PR DESCRIPTION
# Errors

## git clone

```shell
git clone git@github.com:nikolasburk/typegraphql-prisma-crud.git --depth=1
Klone nach 'typegraphql-prisma-crud' ...
Warning: Permanently added the RSA host key for IP address '140.82.121.4' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Konnte nicht vom Remote-Repository lesen.

Bitte stellen Sie sicher, dass die korrekten Zugriffsberechtigungen bestehen
und das Repository existiert.
```

## prisma schema

```shell
yarn run dev
yarn run v1.22.4
warning package.json: No license field
$ ts-node-dev --no-notify --respawn --transpileOnly src/index.ts
Using ts-node version 9.0.0, typescript version 3.8.3
Error: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
In case this error is unexpected for you, please report it in https://github.com/prisma/prisma-client-js/issues/390.
    at new PrismaClient (/Users/muescha/Work/graphql/typegraphql-prisma-crud/node_modules/.prisma/client/index.js:3:11)
    at Object.<anonymous> (/Users/muescha/Work/graphql/typegraphql-prisma-crud/src/context.ts:3:16)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Module._compile (/Users/muescha/Work/graphql/typegraphql-prisma-crud/node_modules/source-map-support/source-map-support.js:547:25)
    at Module.m._compile (/private/var/folders/0j/6_kmjc_51bv7nn26xx2dvrdm0000gn/T/ts-node-dev-hook-19184791577197324.js:57:25)
    at Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at require.extensions.<computed> (/private/var/folders/0j/6_kmjc_51bv7nn26xx2dvrdm0000gn/T/ts-node-dev-hook-19184791577197324.js:59:14)
    at Object.nodeDevHook [as .ts] (/Users/muescha/Work/graphql/typegraphql-prisma-crud/node_modules/ts-node-dev/lib/hook.js:61:7)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
[ERROR] 18:27:22 Error: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
In case this error is unexpected for you, please report it in https://github.com/prisma/prisma-client-js/issues/390.
```

# Description

changed:
- clone command to clone without error
- add `prisma generate` command
- added also yarn commands (because there was a `yarn.lock` already)